### PR TITLE
Update item view with status change

### DIFF
--- a/templates/tarea.html
+++ b/templates/tarea.html
@@ -1,0 +1,54 @@
+<!-- =============================================================================
+     TEMPLATE: DETALLE DE TAREA (SOLO LECTURA + ACCIÓN DE ESTADO)
+     =============================================================================
+     Muestra: Nombre, Estado, Categoría y un botón para actualizar el estado
+     de "pendiente" a "listo".
+     Variables esperadas en el contexto:
+     - tarea: nombre de la tarea (string)
+     - estado: 'pendiente' | 'listo' (string, opcional; por defecto 'pendiente')
+     - categoria_nombre: nombre de la categoría (string, opcional)
+     - indice: índice/identificador de la tarea (para la acción)
+     ============================================================================= -->
+{% extends "layout.html" %}
+{% block title %}Tarea{% endblock %}
+{% block content %}
+<div class="container mt-4">
+  <h1>Tarea</h1>
+
+  {% set estado_actual = estado|default('pendiente') %}
+
+  <div class="card mb-3">
+    <div class="card-body">
+      <div class="mb-2">
+        <strong>Nombre:</strong>
+        <span>{{ tarea }}</span>
+      </div>
+      <div class="mb-2">
+        <strong>Estado:</strong>
+        {% if estado_actual == 'listo' %}
+          <span class="badge text-bg-success">Listo</span>
+        {% else %}
+          <span class="badge text-bg-warning">Pendiente</span>
+        {% endif %}
+      </div>
+      <div class="mb-2">
+        <strong>Categoría:</strong>
+        <span>{{ categoria_nombre|default('-') }}</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="d-flex gap-2">
+    <form action="/tarea/{{ indice }}/actualizar-estado" method="post" class="d-inline">
+      <input type="hidden" name="nuevo_estado" value="listo">
+      {% if estado_actual != 'listo' %}
+        <button type="submit" class="btn btn-primary">Marcar como lista</button>
+      {% else %}
+        <button type="button" class="btn btn-secondary" disabled>Ya está lista</button>
+      {% endif %}
+    </form>
+    <a href="/tareas" class="btn btn-outline-secondary">Volver</a>
+  </div>
+</div>
+{% endblock %}
+


### PR DESCRIPTION
Adds a dedicated task detail view (`/tarea/<indice>`) displaying name, state, and category, with a button to update the task's status from 'pendiente' to 'listo'.

---
<a href="https://cursor.com/background-agent?bcId=bc-7505de85-788a-454c-85f3-1eed27032a09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7505de85-788a-454c-85f3-1eed27032a09">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

